### PR TITLE
mix: compile on more platforms, and handle errors

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -1,16 +1,21 @@
 defmodule Mix.Tasks.Compile.Hoedown do
   def run(_) do
-    if match?({:win32, _}, :os.type()) do
-      {result, _error_code} =
-        System.cmd("nmake", ["/F", "Makefile.win", "priv\\markdown.dll"], stderr_to_stdout: true)
+    {make, args} =
+      case :os.type() do
+        {:win32, _} -> {"nmake", ["/F", "Makefile.win", "priv\\markdown.dll"]}
+        {_, :freebsd} -> {"gmake", ["priv/markdown.so"]}
+        {:unix, _} -> {"make", ["priv/markdown.so"]}
+      end
 
-      IO.binwrite(result)
-    else
-      {result, _error_code} = System.cmd("make", ["priv/markdown.so"], stderr_to_stdout: true)
-      IO.binwrite(result)
+    case System.cmd(make, args, stderr_to_stdout: true) do
+      {result, 0} ->
+        IO.binwrite(result)
+        :ok
+
+      {result, _} ->
+        IO.binwrite(result)
+        :error
     end
-
-    :ok
   end
 end
 


### PR DESCRIPTION
The current invocation assumes that make == gmake, and that it will never fail. Both are fragile assumptions. This is tidier on non-Linux platforms, I can't test on OSX/Windows atm but it's not a massive change.

https://github.com/davisp/erlang-native-compiler is a much smarter alternative, but then needs a dependency, YMMV.

```
$ uname -a FreeBSD wintermute.skunkwerks.at 14.0-CURRENT FreeBSD 14.0-CURRENT main-n244674-a4f26914d4d5 GENERIC-NODEBUG  amd64

$ env MIX_ENV=test mix do compile, test
Removing _build/
Removing priv/markdown.so
Removing src/hoedown/libhoedown.a
Removing src/hoedown/src/autolink.o
Removing src/hoedown/src/buffer.o
Removing src/hoedown/src/document.o
Removing src/hoedown/src/escape.o
Removing src/hoedown/src/html.o
Removing src/hoedown/src/html_blocks.o
Removing src/hoedown/src/html_smartypants.o
Removing src/hoedown/src/stack.o
Removing src/hoedown/src/version.o
HEAD is now at c6d09b2 mix: compile on more platforms, and handle errors
/usr/local/bin/gmake -C src/hoedown libhoedown.a
gmake[1]: Entering directory '/repos/still-markdown/src/hoedown'
cc -g -O3 -ansi -pedantic -Wall -Wextra -Wno-unused-parameter -Isrc -fPIC -c -o src/autolink.o src/autolink.c
cc -g -O3 -ansi -pedantic -Wall -Wextra -Wno-unused-parameter -Isrc -fPIC -c -o src/buffer.o src/buffer.c
cc -g -O3 -ansi -pedantic -Wall -Wextra -Wno-unused-parameter -Isrc -fPIC -c -o src/document.o src/document.c
cc -g -O3 -ansi -pedantic -Wall -Wextra -Wno-unused-parameter -Isrc -fPIC -c -o src/escape.o src/escape.c
cc -g -O3 -ansi -pedantic -Wall -Wextra -Wno-unused-parameter -Isrc -fPIC -c -o src/html.o src/html.c
cc -g -O3 -ansi -pedantic -Wall -Wextra -Wno-unused-parameter -Isrc -fPIC -Wno-static-in-inline -c -o src/html_blocks.o src/html_blocks.c
cc -g -O3 -ansi -pedantic -Wall -Wextra -Wno-unused-parameter -Isrc -fPIC -c -o src/html_smartypants.o src/html_smartypants.c
cc -g -O3 -ansi -pedantic -Wall -Wextra -Wno-unused-parameter -Isrc -fPIC -c -o src/stack.o src/stack.c
cc -g -O3 -ansi -pedantic -Wall -Wextra -Wno-unused-parameter -Isrc -fPIC -c -o src/version.o src/version.c
ar rcs libhoedown.a src/autolink.o src/buffer.o src/document.o src/escape.o src/html.o src/html_blocks.o src/html_smartypants.o src/stack.o src/version.o
gmake[1]: Leaving directory '/repos/still-markdown/src/hoedown'
cc -g -O3 -ansi -pedantic -Wall -Wextra -Wno-unused-parameter -I/usr/local/lib/erlang23/erts-11.1.7/include -Isrc/hoedown/src -fPIC -shared  -o priv/markdown.so src/markdown.c src/hoedown/libhoedown.a
src/markdown.c:241:29: warning: missing field 'flags' initializer [-Wmissing-field-initializers]
    { "to_html", 2, to_html },
                            ^
src/markdown.c:242:49: warning: missing field 'flags' initializer [-Wmissing-field-initializers]
    { "set_nif_threshold", 1, set_nif_threshold }
                                                ^
2 warnings generated.
Compiling 1 file (.ex)
Generated markdown app
..................

Finished in 0.2 seconds
1 doctest, 17 tests, 0 failures

Randomized with seed 791917
```